### PR TITLE
added accelerometer availability checks to useIsShake()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-test-renderer": "^18.3.0",
         "expo": "^51.0.0",
         "expo-image": "~1.12.8",
+        "expo-linking": "~6.3.1",
         "expo-sensors": "~13.0.5",
         "expo-status-bar": "~1.12.1",
         "react": "18.2.0",
@@ -7509,6 +7510,15 @@
       "integrity": "sha512-Kqv8Bf1f5Jp7YMUgTTyKR9GatgHJuAcC8vVWDEkgVhB3O7L3pgBy5MMSMUhkTmRRV6L8TZe/rDmjiBoVS/soFA==",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-linking": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-6.3.1.tgz",
+      "integrity": "sha512-xuZCntSBGWCD/95iZ+mTUGTwHdy8Sx+immCqbUBxdvZ2TN61P02kKg7SaLS8A4a/hLrSCwrg5tMMwu5wfKr35g==",
+      "dependencies": {
+        "expo-constants": "~16.0.0",
+        "invariant": "^2.2.4"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-native": "0.74.1",
     "react-native-svg": "15.2.0-rc.0",
     "save-dev": "^0.0.1-security",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "expo-linking": "~6.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/src/useIsShake.ts
+++ b/src/useIsShake.ts
@@ -91,15 +91,15 @@ export function useIsShake() {
       setIsAccelerometerStatusPending(true);
       checkAccelerometerAvailablity();
     };
-    if (!accelerometerStatus && !isAccelerometerStatusPending) {
+    if (accelerometerStatus === 'not_available' && !isAccelerometerStatusPending) {
       setIsAccelerometerStatusPending(true);
       getAccelerometerPermission();
     };
     // invocation of _subscribe when accelerometer is available and isShakeReady === true
-    if (accelerometerStatus && isShakeReady) {
+    if (accelerometerStatus === 'available' && isShakeReady) {
       _subscribe();
       // isShake Accelerometer listener is removed when !isShakeReady
-    } else if (accelerometerStatus && !isShakeReady) _unsubscribe();
+    } else if (accelerometerStatus === 'available' && !isShakeReady) _unsubscribe();
     return () => _unsubscribe();
   }, [isShakeReady, accelerometerStatus]);
 


### PR DESCRIPTION
Expo recommends that if using any sensor it should first be checked that it is available to app. In this PR I Implemented logic to the hook that will check if the accelerometer is already available, if not it will request permission via an alert for the end user to enable access to the accelerometer, and if the app is not allowed to request permission or permission has been previously denied, the end user will be directed to the Settings of their device to enable permissions for the accelerometer in this app.